### PR TITLE
Make Coordinates optional for D01, D02, D03.

### DIFF
--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -121,106 +121,117 @@ fn main() {
         .into(),
         FunctionCode::GCode(GCode::Comment("Start image generation".to_string())).into(),
         FunctionCode::DCode(DCode::SelectAperture(10)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             0,
             CoordinateNumber::try_from(0.25).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::GCode(GCode::InterpolationMode(InterpolationMode::Linear)).into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(0, 0, cf),
+            Some(Coordinates::new(0, 0, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(CoordinateNumber::try_from(0.25).unwrap(), 0, cf),
+            Some(Coordinates::new(
+                CoordinateNumber::try_from(0.25).unwrap(),
+                0,
+                cf,
+            )),
             None,
         )))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             1, 1, cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(CoordinateNumber::try_from(1.5).unwrap(), cf),
+            Some(Coordinates::at_x(
+                CoordinateNumber::try_from(1.5).unwrap(),
+                cf,
+            )),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(2, CoordinateNumber::try_from(1.5).unwrap(), cf),
+            Some(Coordinates::new(
+                2,
+                CoordinateNumber::try_from(1.5).unwrap(),
+                cf,
+            )),
             None,
         )))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::at_x(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::at_x(
             CoordinateNumber::try_from(2.5).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(1, cf),
+            Some(Coordinates::at_y(1, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(11)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             1, 1, cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             2, 1, cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(2.5).unwrap(),
             1,
             cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(2.5).unwrap(),
             CoordinateNumber::try_from(1.5).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             2,
             CoordinateNumber::try_from(1.5).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(12)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             1,
             CoordinateNumber::try_from(1.5).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(13)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             3,
             CoordinateNumber::try_from(1.5).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(14)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             3,
             CoordinateNumber::try_from(1.25).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(15)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             3, 1, cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(10)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             CoordinateNumber::try_from(3.75).unwrap(),
             1,
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::GCode(GCode::QuadrantMode(QuadrantMode::Multi)).into(),
         FunctionCode::GCode(GCode::InterpolationMode(
@@ -228,7 +239,11 @@ fn main() {
         ))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(CoordinateNumber::try_from(3.75).unwrap(), 1, cf),
+            Some(Coordinates::new(
+                CoordinateNumber::try_from(3.75).unwrap(),
+                1,
+                cf,
+            )),
             Some(CoordinateOffset::new(
                 CoordinateNumber::try_from(0.25).unwrap(),
                 0,
@@ -237,71 +252,80 @@ fn main() {
         )))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(16)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(3.4).unwrap(),
             1,
             cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(3.5).unwrap(),
             CoordinateNumber::try_from(0.9).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(10)).into(),
         FunctionCode::GCode(GCode::RegionMode(true)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             CoordinateNumber::try_from(0.5).unwrap(),
             2,
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::GCode(GCode::InterpolationMode(InterpolationMode::Linear)).into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(CoordinateNumber::try_from(3.75).unwrap(), cf),
+            Some(Coordinates::at_y(
+                CoordinateNumber::try_from(3.75).unwrap(),
+                cf,
+            )),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(CoordinateNumber::try_from(3.75).unwrap(), cf),
+            Some(Coordinates::at_x(
+                CoordinateNumber::try_from(3.75).unwrap(),
+                cf,
+            )),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(2, cf),
+            Some(Coordinates::at_y(2, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(CoordinateNumber::try_from(0.5).unwrap(), cf),
+            Some(Coordinates::at_x(
+                CoordinateNumber::try_from(0.5).unwrap(),
+                cf,
+            )),
             None,
         )))
         .into(),
         FunctionCode::GCode(GCode::RegionMode(false)).into(),
         FunctionCode::DCode(DCode::SelectAperture(18)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             0,
             CoordinateNumber::try_from(3.875).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(3.875).unwrap(),
             CoordinateNumber::try_from(3.875).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         ExtendedCode::LoadPolarity(Polarity::Clear).into(),
         FunctionCode::GCode(GCode::RegionMode(true)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             1,
             CoordinateNumber::try_from(2.5).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(3, cf),
+            Some(Coordinates::at_y(3, cf)),
             None,
         )))
         .into(),
@@ -311,11 +335,11 @@ fn main() {
         ))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(
+            Some(Coordinates::new(
                 CoordinateNumber::try_from(1.25).unwrap(),
                 CoordinateNumber::try_from(3.25).unwrap(),
                 cf,
-            ),
+            )),
             Some(CoordinateOffset::new(
                 CoordinateNumber::try_from(0.25).unwrap(),
                 0,
@@ -325,7 +349,7 @@ fn main() {
         .into(),
         FunctionCode::GCode(GCode::InterpolationMode(InterpolationMode::Linear)).into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(3, cf),
+            Some(Coordinates::at_x(3, cf)),
             None,
         )))
         .into(),
@@ -335,7 +359,11 @@ fn main() {
         ))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(3, CoordinateNumber::try_from(2.5).unwrap(), cf),
+            Some(Coordinates::new(
+                3,
+                CoordinateNumber::try_from(2.5).unwrap(),
+                cf,
+            )),
             Some(CoordinateOffset::new(
                 0,
                 CoordinateNumber::try_from(0.375).unwrap(),
@@ -345,38 +373,41 @@ fn main() {
         .into(),
         FunctionCode::GCode(GCode::InterpolationMode(InterpolationMode::Linear)).into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(1, cf),
+            Some(Coordinates::at_x(1, cf)),
             None,
         )))
         .into(),
         FunctionCode::GCode(GCode::RegionMode(false)).into(),
         ExtendedCode::LoadPolarity(Polarity::Dark).into(),
         FunctionCode::DCode(DCode::SelectAperture(10)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             CoordinateNumber::try_from(1.5).unwrap(),
             CoordinateNumber::try_from(2.875).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(2, cf),
+            Some(Coordinates::at_x(2, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(11)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(1.5).unwrap(),
             CoordinateNumber::try_from(2.875).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::at_x(2, cf)))).into(),
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::at_x(
+            2, cf,
+        )))))
+        .into(),
         FunctionCode::DCode(DCode::SelectAperture(19)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Flash(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Flash(Some(Coordinates::new(
             CoordinateNumber::try_from(2.875).unwrap(),
             CoordinateNumber::try_from(2.875).unwrap(),
             cf,
-        ))))
+        )))))
         .into(),
         ExtendedCode::FileAttribute(FileAttribute::Md5(
             "6ab9e892830469cdff7e3e346331d404".to_string(),

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -34,49 +34,52 @@ fn main() {
         })
         .into(),
         FunctionCode::DCode(DCode::SelectAperture(10)).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::new(
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             0, 0, cf,
-        ))))
+        )))))
         .into(),
         FunctionCode::GCode(GCode::InterpolationMode(InterpolationMode::Linear)).into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::new(5, 0, cf),
+            Some(Coordinates::new(5, 0, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(5, cf),
+            Some(Coordinates::at_y(5, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(0, cf),
+            Some(Coordinates::at_x(0, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(0, cf),
+            Some(Coordinates::at_y(0, cf)),
             None,
         )))
         .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Move(Coordinates::at_x(6, cf)))).into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(11, cf),
-            None,
-        )))
+        FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::at_x(
+            6, cf,
+        )))))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(5, cf),
-            None,
-        )))
-        .into(),
-        FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_x(6, cf),
+            Some(Coordinates::at_x(11, cf)),
             None,
         )))
         .into(),
         FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
-            Coordinates::at_y(0, cf),
+            Some(Coordinates::at_y(5, cf)),
+            None,
+        )))
+        .into(),
+        FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
+            Some(Coordinates::at_x(6, cf)),
+            None,
+        )))
+        .into(),
+        FunctionCode::DCode(DCode::Operation(Operation::Interpolate(
+            Some(Coordinates::at_y(0, cf)),
             None,
         )))
         .into(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,9 @@ pub enum GerberError {
 
     #[error("I/O error during code generation")]
     IoError(#[from] IoError),
+
+    #[error("Empty coordinates")]
+    EmptyCoordinates,
 }
 
 pub type GerberResult<T> = Result<T, GerberError>;

--- a/src/function_codes.rs
+++ b/src/function_codes.rs
@@ -73,11 +73,14 @@ impl<W: Write> GerberCode<W> for MCode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Operation {
     /// D01 Command
-    Interpolate(Coordinates, Option<CoordinateOffset>),
+    /// `D01 = ['X' integer] ['Y' integer] ['I' integer 'J' integer] 'D01*';`
+    Interpolate(Option<Coordinates>, Option<CoordinateOffset>),
     /// D02 Command
-    Move(Coordinates),
+    /// `['X' integer] ['Y' integer] 'D02*';`
+    Move(Option<Coordinates>),
     /// D03 Command
-    Flash(Coordinates),
+    /// `['X' integer] ['Y' integer] 'D03*';`
+    Flash(Option<Coordinates>),
 }
 
 impl<W: Write> GerberCode<W> for Operation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,15 +115,18 @@ mod serialization_tests {
     fn test_operation_interpolate() {
         let cf = CoordinateFormat::new(2, 5);
         let c1 = Operation::Interpolate(
-            Coordinates::new(1, 2, cf),
+            Some(Coordinates::new(1, 2, cf)),
             Some(CoordinateOffset::new(5, 10, cf)),
         );
         assert_code!(c1, "X100000Y200000I500000J1000000D01*\n");
-        let c2 = Operation::Interpolate(Coordinates::at_y(-2, CoordinateFormat::new(4, 4)), None);
+        let c2 = Operation::Interpolate(
+            Some(Coordinates::at_y(-2, CoordinateFormat::new(4, 4))),
+            None,
+        );
         assert_code!(c2, "Y-20000D01*\n");
         let cf = CoordinateFormat::new(4, 4);
         let c3 = Operation::Interpolate(
-            Coordinates::at_x(1, cf),
+            Some(Coordinates::at_x(1, cf)),
             Some(CoordinateOffset::at_y(2, cf)),
         );
         assert_code!(c3, "X10000J20000D01*\n");
@@ -131,13 +134,13 @@ mod serialization_tests {
 
     #[test]
     fn test_operation_move() {
-        let c = Operation::Move(Coordinates::new(23, 42, CoordinateFormat::new(6, 4)));
+        let c = Operation::Move(Some(Coordinates::new(23, 42, CoordinateFormat::new(6, 4))));
         assert_code!(c, "X230000Y420000D02*\n");
     }
 
     #[test]
     fn test_operation_flash() {
-        let c = Operation::Flash(Coordinates::new(23, 42, CoordinateFormat::new(4, 4)));
+        let c = Operation::Flash(Some(Coordinates::new(23, 42, CoordinateFormat::new(4, 4))));
         assert_code!(c, "X230000Y420000D03*\n");
     }
 


### PR DESCRIPTION
Since `Operation` specifies an `Option<CoordinateOffset>` it is inconsistent to allow both of these states:

a) `Operation::Interpolate { _, Some(CoordinateOffset { x: None, y: None })}` 
b) `Operation::Interpolate { _, None }`,

* If a viewer encounters the first state, it should generate a warning.
* A parser should never generate the first state (a) to begin with and generate (b) instead.

To be consistent, it's now invalid for both Coordinate and CoordinateOffset to have neither X nor Y.  Instead, `None` should be used for the `Coordinate` or `CoordinateOffset` instance itself.

* this answers the long-standing 'should we catch this' question, the answer is YES.