### PR TITLE
Add support for comment attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Possible log types:
 - `[fixed]` for any bug fixes.
 - `[security]` to invite users to upgrade in case of vulnerabilities.
 
+### v0.6.0 (2025-07-10)
+
+- [added] Added support for G04 'standard comments' where comment attributes are placed in G04 commands.
+  e.g. 'G04 #@! TA.AperFunction,SMDPad,CuDef*'
+  This means that when you're looking for attributes, you now have to look in two places:
+  1) `Command::ExtendedCode(ExtendedCode::[FileAttribute|ObjectAttribute|ApertureAttribute])` and 
+  2) `Command::FunctionCode(FunctionCode::GCode(GCode::Comment(CommentContent::Standard(StandardComment::[FileAttribute|ObjectAttribute|ApertureAttribute]))))`
+  It also means when you're making/serializing gerber files you need to choose where to put the attributes.
+  Refer to Gerber spec 2024.05 - "4.1 Comment (G04)" and "5.1.1 Comment attributes".
+  Unfortunately, in 2025, manufacturing files containing comment attributes are still widespread.
+- [changed] Removed 'Eq' from `FunctionCode`, due to use of `f64` in attributes (`ExtendedCode` wasn't `Eq` either)
+
 ### v0.5.0 (2025-07-10)
 
 - [added] Support for legacy/deprecated gerber commands: `IP`, `MI`, `SF`, `OF`, `IR`, and `AS`.

--- a/examples/polarities-apertures.rs
+++ b/examples/polarities-apertures.rs
@@ -11,7 +11,10 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 fn main() {
     let cf = CoordinateFormat::new(2, 6);
     let commands: Vec<Command> = vec![
-        FunctionCode::GCode(GCode::Comment("Ucamco ex. 2: Shapes".to_string())).into(),
+        FunctionCode::GCode(GCode::Comment(CommentContent::String(
+            "Ucamco ex. 2: Shapes".to_string(),
+        )))
+        .into(),
         ExtendedCode::CoordinateFormat(cf).into(),
         ExtendedCode::Unit(Unit::Inches).into(),
         ExtendedCode::FileAttribute(FileAttribute::GenerationSoftware(GenerationSoftware::new(
@@ -25,7 +28,10 @@ fn main() {
         )))
         .into(),
         ExtendedCode::LoadPolarity(Polarity::Dark).into(),
-        FunctionCode::GCode(GCode::Comment("Define Apertures".to_string())).into(),
+        FunctionCode::GCode(GCode::Comment(CommentContent::String(
+            "Define Apertures".to_string(),
+        )))
+        .into(),
         ExtendedCode::ApertureMacro(ApertureMacro::new("TARGET125").add_content(MoirePrimitive {
             center: (0.0.into(), 0.0.into()),
             diameter: 0.125.into(),
@@ -119,7 +125,10 @@ fn main() {
             aperture: Aperture::Macro("THERMAL80".to_string(), None),
         })
         .into(),
-        FunctionCode::GCode(GCode::Comment("Start image generation".to_string())).into(),
+        FunctionCode::GCode(GCode::Comment(CommentContent::String(
+            "Start image generation".to_string(),
+        )))
+        .into(),
         FunctionCode::DCode(DCode::SelectAperture(10)).into(),
         FunctionCode::DCode(DCode::Operation(Operation::Move(Some(Coordinates::new(
             0,

--- a/examples/two-boxes.rs
+++ b/examples/two-boxes.rs
@@ -4,8 +4,8 @@
 use std::io::stdout;
 
 use gerber_types::{
-    Aperture, ApertureDefinition, Circle, Command, CoordinateFormat, Coordinates, DCode,
-    ExtendedCode, FileAttribute, FunctionCode, GCode, GenerationSoftware, GerberCode,
+    Aperture, ApertureDefinition, Circle, Command, CommentContent, CoordinateFormat, Coordinates,
+    DCode, ExtendedCode, FileAttribute, FunctionCode, GCode, GenerationSoftware, GerberCode,
     InterpolationMode, MCode, Operation, Part, Polarity, Unit,
 };
 
@@ -14,7 +14,10 @@ const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 fn main() {
     let cf = CoordinateFormat::new(2, 6);
     let commands: Vec<Command> = vec![
-        FunctionCode::GCode(GCode::Comment("Ucamco ex. 1: Two square boxes".to_string())).into(),
+        FunctionCode::GCode(GCode::Comment(CommentContent::String(
+            "Ucamco ex. 1: Two square boxes".to_string(),
+        )))
+        .into(),
         ExtendedCode::Unit(Unit::Millimeters).into(),
         ExtendedCode::CoordinateFormat(cf).into(),
         ExtendedCode::FileAttribute(FileAttribute::GenerationSoftware(GenerationSoftware::new(

--- a/src/types.rs
+++ b/src/types.rs
@@ -47,7 +47,7 @@ macro_rules! impl_command_fromfrom {
 
 // Main categories
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FunctionCode {
     DCode(function_codes::DCode),
     GCode(function_codes::GCode),
@@ -185,26 +185,30 @@ mod test {
     use crate::extended_codes::Polarity;
     use crate::function_codes::GCode;
     use crate::traits::GerberCode;
-    use crate::{ApertureBlock, Mirroring, Rotation, Scaling, StepAndRepeat};
+    use crate::{ApertureBlock, CommentContent, Mirroring, Rotation, Scaling, StepAndRepeat};
 
     #[test]
     fn test_debug() {
         //! The debug representation should work properly.
-        let c = Command::FunctionCode(FunctionCode::GCode(GCode::Comment("test".to_string())));
+        let c = Command::FunctionCode(FunctionCode::GCode(GCode::Comment(CommentContent::String(
+            "test".to_string(),
+        ))));
         let debug = format!("{:?}", c);
-        assert_eq!(debug, "FunctionCode(GCode(Comment(\"test\")))");
+        assert_eq!(debug, "FunctionCode(GCode(Comment(String(\"test\"))))");
     }
 
     #[test]
     fn test_function_code_serialize() {
         //! A `FunctionCode` should implement `GerberCode`
-        let c = FunctionCode::GCode(GCode::Comment("comment".to_string()));
+        let c = FunctionCode::GCode(GCode::Comment(CommentContent::String(
+            "comment".to_string(),
+        )));
         assert_code!(c, "G04 comment*\n");
     }
 
     #[test]
     fn test_function_code_from_gcode() {
-        let comment = GCode::Comment("hello".into());
+        let comment = GCode::Comment(CommentContent::String("hello".into()));
         let f1: FunctionCode = FunctionCode::GCode(comment.clone());
         let f2: FunctionCode = comment.into();
         assert_eq!(f1, f2);
@@ -212,7 +216,7 @@ mod test {
 
     #[test]
     fn test_command_from_function_code() {
-        let comment = FunctionCode::GCode(GCode::Comment("hello".into()));
+        let comment = FunctionCode::GCode(GCode::Comment(CommentContent::String("hello".into())));
         let c1: Command = Command::FunctionCode(comment.clone());
         let c2: Command = comment.into();
         assert_eq!(c1, c2);


### PR DESCRIPTION
This PR adds support for comment attributes.

> For example,
> `TA.AperFunction,SMDPad,CuDef*`
> can be written as
> `G04 #@! TA.AperFunction,SMDPad,CuDef*`

This complicates things for parsers, tool and writers, since now parsers and tools have to look in two places for attributes and writers have to decide which gerber commands to create to store attributes.

However, in order to make sure that they are supported by gerber-types this is the approach that must be taken so that the onus is on the down-stream crate to decide what they support.