### PR TITLE
Add support for `IN` ImageName command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Possible log types:
   It also means when you're making/serializing gerber files you need to choose where to put the attributes.
   Refer to Gerber spec 2024.05 - "4.1 Comment (G04)" and "5.1.1 Comment attributes".
   Unfortunately, in 2025, manufacturing files containing comment attributes are still widespread.
+- [added] Added support for `IN` (ImageName) command.
 - [changed] Removed 'Eq' from `FunctionCode`, due to use of `f64` in attributes (`ExtendedCode` wasn't `Eq` either)
 
 ### v0.5.0 (2025-07-10)

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -159,6 +159,11 @@ impl<W: Write> GerberCode<W> for ExtendedCode {
                 r#as.serialize_partial(writer)?;
                 writeln!(writer, "*%")?;
             }
+            ExtendedCode::ImageName(ref r#in) => {
+                write!(writer, "%IN")?;
+                r#in.serialize_partial(writer)?;
+                writeln!(writer, "*%")?;
+            }
         };
         Ok(())
     }

--- a/src/extended_codes.rs
+++ b/src/extended_codes.rs
@@ -531,3 +531,17 @@ impl Default for ImagePolarity {
         ImagePolarity::Positive
     }
 }
+
+/// Gerber spec 2024.05 8.1.9 "Scale Factor (SF)"
+/// By default, A=X, B=Y, but this changes depending on the axis select command (AS)
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageName {
+    pub name: String,
+}
+
+impl<W: Write> PartialGerberCode<W> for ImageName {
+    fn serialize_partial(&self, writer: &mut W) -> GerberResult<()> {
+        write!(writer, "{}", self.name)?;
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1614,4 +1614,12 @@ mod serialization_tests {
         let value = ExtendedCode::AxisSelect(AxisSelect::AYBX);
         assert_code!(value, "%ASAYBX*%\n");
     }
+
+    #[test]
+    fn test_image_name() {
+        let value = ExtendedCode::ImageName(ImageName {
+            name: "PANEL_1".to_string(),
+        });
+        assert_code!(value, "%INPANEL_1*%\n");
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -104,6 +104,8 @@ pub enum ExtendedCode {
     ImagePolarity(extended_codes::ImagePolarity),
     /// AS (deprecated in gerber spec since December 2012)
     AxisSelect(extended_codes::AxisSelect),
+    /// IN (deprecated in gerber spec since October 2013)
+    ImageName(extended_codes::ImageName),
 }
 
 impl_from!(


### PR DESCRIPTION
This PR adds support for the deprecated `IN` command.

There was a workaround in the `gerber-parser` that will no longer be necessary when this is merged.